### PR TITLE
Add scales package

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ install_github("filipematias23/FIELDimageR")
 install.packages("sp")
 install.packages("raster")
 install.packages("rgdal")
+install.packages("scales")
 
 library(FIELDimageR)
 library(raster)


### PR DESCRIPTION
Without this package I couldn't execute the EX1.Crop <- fieldCrop(mosaic=EX1)` command: ``` Error in loadNamespace(name) : there is no package called ?scales? ```

