### PR TITLE
Fix: Fixed Dockerfile with BiocManager Installation giving error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-dev \ 		
     libudunits2-dev
 
+RUN Rscript -e 'BiocManager::install(version = "3.13", ask = FALSE)'
 RUN Rscript -e 'BiocManager::install("EBImage", version = "3.13")'
 
 RUN install2.r --error \


### PR DESCRIPTION
I fixed the creation of the Dockerised container, giving the following error. 

![image](https://user-images.githubusercontent.com/12731278/144667385-87dfd32d-cf19-448c-a28e-9b505034d083.png)

After updating the Dockerised version of FieldImageR works absolutely fine. 

![image](https://user-images.githubusercontent.com/12731278/144667644-e69588e0-5295-45de-9c39-f2abfa8d1675.png)

