### PR TITLE
Fix: Updated Dockerfile with igraph dependency fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rocker/tidyverse:4.1.0
 LABEL maintainer="Kenyon Ng <work@kenyon.xyz>"
 
-# libfftw3-dev (EBImage), libgdal-dev (s2), libudunits2-dev (units), the rest (sf)
+# libfftw3-dev (EBImage), libgdal-dev (s2), libudunits2-dev (units), the rest (sf), libglpk40(igraph)
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libfftw3-dev \		
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgeos++-dev \
     libproj-dev \
     libsqlite3-dev \ 		
-    libudunits2-dev
+    libudunits2-dev \ 
+    libglpk40
 
 RUN Rscript -e 'BiocManager::install(version = "3.13", ask = FALSE)'
 RUN Rscript -e 'BiocManager::install("EBImage", version = "3.13")'


### PR DESCRIPTION
The library ```igraph``` was not loading even after installing it with dependencies using R, because a base dependency of ```libglpk40``` was unmet. 
![image](https://user-images.githubusercontent.com/12731278/146677732-1d115d5d-99b6-4928-9943-77ca599ed96f.png)

Have updated the Dockerfile to install the dependency at the start, and the bug has been successfully resolved now. 
![image](https://user-images.githubusercontent.com/12731278/146677755-35fc3d6b-3cca-4834-bdd2-1a455681aee8.png)
